### PR TITLE
fix: main.scss -> index.scss로 파일명 변경으로 인한 index.html css 참조 경로 수정

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,6 +8,7 @@
 			rel="stylesheet"
 			href="https://cdn.jsdelivr.net/npm/reset-css@5.0.1/reset.min.css"
 		/>
+		<!--main.scss -> index.scss로 경로 수정-->
 		<link rel="stylesheet" href="./src/styles/index.scss" />
 		<script defer src="./src/modules/router.js"></script>
 		<script defer src="./src/modules/my.js"></script>

--- a/index.html
+++ b/index.html
@@ -8,7 +8,7 @@
 			rel="stylesheet"
 			href="https://cdn.jsdelivr.net/npm/reset-css@5.0.1/reset.min.css"
 		/>
-		<link rel="stylesheet" href="./src/styles/main.scss" />
+		<link rel="stylesheet" href="./src/styles/index.scss" />
 		<script defer src="./src/modules/router.js"></script>
 		<script defer src="./src/modules/my.js"></script>
 		<title>Document</title>


### PR DESCRIPTION
# 문제상황
- 메인페이지 css와 기존의 main.scss와 충돌되는 문제 발생 #54 
- main.scss-> index.scss로 코드 이동 및 파일명 변경으로 인한 index.html css파일경로 재설정 필요

# 해결방법
- [x] #54 문제 해결을 위한 main.scss에서 index.scss로 파일 추가 #70 
- [x] index.html에 css 참조경로 index.scss로 수정 완료