### PR TITLE
fix: 공통헤더 CSS 경로 수정

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,6 +8,7 @@
 			rel="stylesheet"
 			href="https://cdn.jsdelivr.net/npm/reset-css@5.0.1/reset.min.css"
 		/>
+		<!--main.scss -> index.scss로 경로 수정-->
 		<link rel="stylesheet" href="./src/styles/index.scss" />
 		<script defer src="./src/modules/router.js"></script>
 		<script defer src="./src/modules/my.js"></script>

--- a/index.html
+++ b/index.html
@@ -8,7 +8,7 @@
 			rel="stylesheet"
 			href="https://cdn.jsdelivr.net/npm/reset-css@5.0.1/reset.min.css"
 		/>
-		<link rel="stylesheet" href="./src/styles/main.scss" />
+		<link rel="stylesheet" href="./src/styles/index.scss" />
 		<script defer src="./src/modules/router.js"></script>
 		<script defer src="./src/modules/my.js"></script>
 		<title>Document</title>

--- a/src/styles/index.scss
+++ b/src/styles/index.scss
@@ -1,3 +1,3 @@
 @import url(./home.scss);
 @import url(./my.scss);
-@import url(./header.scss);
+@import url(./header.css);


### PR DESCRIPTION
# 문제상황
-  공통헤더 메인 css파일을 header.scss에서 header.css로 변경됨.
- 이로인해 기존 index.scss에서 import했던 공통헤더 메인 css파일 경로 수정으로 인한 레이아웃 깨짐 현상 발생 가능성 고려 필요.

# 해결방법
- [x] index.scss에서 import 되어 있는 header.scss -> header.css 로 변경