### PR TITLE
feat: 공통헤더 로그인/로그아웃 기능 구현 및 '반가워요 집사님!' 버튼 라우팅 추가

### DIFF
--- a/src/components/templates/header.js
+++ b/src/components/templates/header.js
@@ -1,3 +1,5 @@
+import request from "../../api/common";
+
 const Header = document.createElement("header");
 const headerWrapper = document.createElement("div");
 const mainLogoBtn = document.createElement("a");
@@ -6,7 +8,8 @@ const searchBtnWrapper = document.createElement("div");
 const searchBar = document.createElement("input");
 const searchBtn = document.createElement("img");
 const welcomeWord = document.createElement("span");
-const logoutBtn = document.createElement("span");
+const btn = document.createElement("a");
+const nameOfBtn = document.createElement("span");
 
 Header.className = "my-header";
 headerWrapper.className = "my-header-wrapper";
@@ -16,7 +19,8 @@ searchBtnWrapper.className = "search-btn-wrapper";
 searchBar.className = "search-bar";
 searchBtn.className = "search-btn";
 welcomeWord.className = "welcome-word";
-logoutBtn.className = "logout";
+btn.className = "btn";
+nameOfBtn.className = "btn-name";
 
 mainLogoBtn.href = "/";
 mainLogoBtnImage.src = require("../../asset/global/main-logo.png");
@@ -26,11 +30,31 @@ searchBar.placeholder = "검색어를 입력해주세요.";
 searchBtn.src = require("../../asset/btnImg/search_btn.png");
 searchBtn.alt = "search-button";
 welcomeWord.innerText = "반가워요, 집사님!";
-logoutBtn.innerText = "로그아웃";
+nameOfBtn.innerText = "로그아웃";
 
 mainLogoBtn.append(mainLogoBtnImage);
 searchBtnWrapper.append(searchBar, searchBtn);
-headerWrapper.append(mainLogoBtn, searchBtnWrapper, welcomeWord, logoutBtn);
+btn.append(nameOfBtn);
+headerWrapper.append(mainLogoBtn, searchBtnWrapper, welcomeWord, btn);
 Header.append(headerWrapper);
 
+btn.addEventListener("click", () => {
+	if (nameOfBtn.innerText === "로그인") {
+		nameOfBtn.innerText = "로그아웃";
+		welcomeWord.innerText = "반가워요, 집사님!";
+	} else {
+		nameOfBtn.innerText = "로그인";
+		welcomeWord.innerText = "";
+		setLogout();
+	}
+});
+
 export default Header;
+// localStorage.setItem("accessToken", 12345); 로컬통신확인용 임의로 집어넣음
+function setLogout() {
+	const token = JSON.parse(localStorage.getItem("accessToken"));
+	if (token) {
+		// console.log("로컬스토리지 토큰 존재여부 체크 완료!");
+		request("MEB04");
+	}
+}

--- a/src/components/templates/header.js
+++ b/src/components/templates/header.js
@@ -1,4 +1,5 @@
 import request from "../../api/common";
+const token = JSON.parse(localStorage.getItem("accessToken"));
 
 const Header = document.createElement("header");
 const headerWrapper = document.createElement("div");
@@ -7,9 +8,12 @@ const mainLogoBtnImage = document.createElement("img");
 const searchBtnWrapper = document.createElement("div");
 const searchBar = document.createElement("input");
 const searchBtn = document.createElement("img");
-const welcomeWord = document.createElement("span");
-const btn = document.createElement("a");
-const nameOfBtn = document.createElement("span");
+const welcomeWord = document.createElement("a");
+const loginBtn = document.createElement("a");
+const logoutBtn = document.createElement("a");
+const word = document.createElement("span");
+const nameOfLoginBtn = document.createElement("span");
+const nameOfLogoutBtn = document.createElement("span");
 
 Header.className = "my-header";
 headerWrapper.className = "my-header-wrapper";
@@ -19,8 +23,11 @@ searchBtnWrapper.className = "search-btn-wrapper";
 searchBar.className = "search-bar";
 searchBtn.className = "search-btn";
 welcomeWord.className = "welcome-word";
-btn.className = "btn";
-nameOfBtn.className = "btn-name";
+word.className = "word";
+loginBtn.className = "btn";
+logoutBtn.className = "btn";
+nameOfLoginBtn.className = "btn-name";
+nameOfLogoutBtn.className = "btn-name";
 
 mainLogoBtn.href = "/";
 mainLogoBtnImage.src = require("../../asset/global/main-logo.png");
@@ -29,32 +36,53 @@ searchBar.type = "text";
 searchBar.placeholder = "검색어를 입력해주세요.";
 searchBtn.src = require("../../asset/btnImg/search_btn.png");
 searchBtn.alt = "search-button";
-welcomeWord.innerText = "반가워요, 집사님!";
-nameOfBtn.innerText = "로그아웃";
+welcomeWord.setAttribute("data-navigo", "");
+welcomeWord.href = getNextUrl();
+word.innerText = "반가워요, 집사님!";
+loginBtn.setAttribute("data-navigo", "");
+loginBtn.href = "/login";
+logoutBtn.setAttribute("data-navigo", "");
+logoutBtn.href = "/";
+nameOfLoginBtn.innerText = "로그인";
+nameOfLogoutBtn.innerText = "로그아웃";
+!token ? (logoutBtn.style.display = "none") : (loginBtn.style.display = "none");
 
 mainLogoBtn.append(mainLogoBtnImage);
 searchBtnWrapper.append(searchBar, searchBtn);
-btn.append(nameOfBtn);
-headerWrapper.append(mainLogoBtn, searchBtnWrapper, welcomeWord, btn);
+welcomeWord.append(word);
+loginBtn.append(nameOfLoginBtn);
+logoutBtn.append(nameOfLogoutBtn);
+headerWrapper.append(mainLogoBtn, searchBtnWrapper);
+!token
+	? headerWrapper.append(loginBtn)
+	: headerWrapper.append(welcomeWord, logoutBtn);
 Header.append(headerWrapper);
 
-btn.addEventListener("click", () => {
-	if (nameOfBtn.innerText === "로그인") {
-		nameOfBtn.innerText = "로그아웃";
-		welcomeWord.innerText = "반가워요, 집사님!";
-	} else {
-		nameOfBtn.innerText = "로그인";
-		welcomeWord.innerText = "";
-		setLogout();
-	}
+loginBtn.addEventListener("click", () => {
+	loginBtn.style.display = "none";
+	logoutBtn.style.display = "inline-block";
 });
 
-export default Header;
-// localStorage.setItem("accessToken", 12345); 로컬통신확인용 임의로 집어넣음
+logoutBtn.addEventListener("click", () => {
+	loginBtn.style.display = "inline-block";
+	logoutBtn.style.display = "none";
+	setLogout();
+});
+
 function setLogout() {
-	const token = JSON.parse(localStorage.getItem("accessToken"));
 	if (token) {
-		// console.log("로컬스토리지 토큰 존재여부 체크 완료!");
 		request("MEB04");
+		window.localStorage.clear();
 	}
 }
+
+function getNextUrl() {
+	const id = JSON.parse(localStorage.getItem("id"));
+	if (id === "admin@zipsa.com") {
+		return "/admin";
+	} else {
+		return "/my";
+	}
+}
+
+export default Header;

--- a/src/styles/header.css
+++ b/src/styles/header.css
@@ -60,7 +60,7 @@
   font-size: 1em;
   font-weight: 600;
 }
-#app .my-header .my-header-wrapper .logout {
+#app .my-header .my-header-wrapper .btn {
   font-size: 1em;
   font-weight: 600;
   margin-right: 0.2em;

--- a/src/styles/header.css
+++ b/src/styles/header.css
@@ -57,10 +57,18 @@
   right: 0.6em;
 }
 #app .my-header .my-header-wrapper .welcome-word {
+  text-decoration: none;
+  color: #000;
+}
+#app .my-header .my-header-wrapper .welcome-word .word {
   font-size: 1em;
   font-weight: 600;
 }
 #app .my-header .my-header-wrapper .btn {
+  text-decoration: none;
+  color: #000;
+}
+#app .my-header .my-header-wrapper .btn .btn-name {
   font-size: 1em;
   font-weight: 600;
   margin-right: 0.2em;

--- a/src/styles/header.scss
+++ b/src/styles/header.scss
@@ -61,7 +61,7 @@
 				font-size: 1em;
 				font-weight: 600;
 			}
-			.logout {
+			.btn {
 				font-size: 1em;
 				font-weight: 600;
 				margin-right: 0.2em;

--- a/src/styles/header.scss
+++ b/src/styles/header.scss
@@ -58,13 +58,21 @@
 			}
 
 			.welcome-word {
-				font-size: 1em;
-				font-weight: 600;
+				text-decoration: none;
+				color: #000;
+				.word {
+					font-size: 1em;
+					font-weight: 600;
+				}
 			}
 			.btn {
-				font-size: 1em;
-				font-weight: 600;
-				margin-right: 0.2em;
+				text-decoration: none;
+				color: #000;
+				.btn-name {
+					font-size: 1em;
+					font-weight: 600;
+					margin-right: 0.2em;
+				}
 			}
 		}
 	}

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -1,6 +1,8 @@
-@import url(./home.scss);
-@import url(./footer.scss);
 @import url(./my.scss);
-@import url(./login.scss);
 @import url(./join.scss);
-@import url(./header.css);/*# sourceMappingURL=index.css.map */
+@import url(./header.scss);
+@import url(./payment.css);
+@import url(./paymentDone.css);
+@import url(./login.css);
+@import url(./admin.css);
+@import url(./footer.css);/*# sourceMappingURL=index.css.map */

--- a/src/styles/index.scss
+++ b/src/styles/index.scss
@@ -1,7 +1,7 @@
 // @import url(./footer.scss);
 @import url(./my.scss);
 @import url(./join.scss);
-@import url(./header.css);
+@import url(./header.scss);
 @import url(./payment.css);
 @import url(./paymentDone.css);
 @import url(./login.css);


### PR DESCRIPTION
# 필수요구사항
- [x] 로컬 스토리지에 aceesToken 존재하지 않으면 로그인 버튼만 노출되어야 한다.
- [x] 로컬 스토리지에 aceesToken 존재하면 로그아웃 버튼과 '반가워요, 집사님!'버튼만 노출되어야 한다.
- [x] 로그인 버튼을 클릭하면 '/login'으로 라우팅 되어야 한다. #114 
- [x] '어드민 계정'으로 로그인한 경우, 공통헤더 '반가워요, 집사님!' 버튼 클릭시  '/admin'으로 이동 가능해야 한다. #111 
- [x] 그외 타 계정으로 로그인한 경우, 공통헤더 '반가워요, 집사님!' 버튼 클릭시  '/my'로 이동 가능해야 한다. #111 
- [x] 공통헤더에 로그아웃 버튼을 클릭했을때 '로그아웃' 및 '반가워요 집사님!'은 사라지고 로그아웃 API를 호출한다. #56 
- [x] 로그아웃 버튼 클릭 한 후 '/' 메인페이지로 라우팅 되어야 한다. #56 
- [x] 응답이 완료되면, 로그아웃 버튼과 '반가워요 집사님!'은 사라지고 로그인 버튼이 노출되어야 한다. #56 